### PR TITLE
Issues rendering state diagrams for any machines that renders → on windows machine

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -640,14 +640,14 @@ files = [
 ]
 
 [[package]]
-name = "render-html"
-version = "1.0.1"
+name = "render-html-v2"
+version = "1.0.0"
 description = "Python library that provides a simple way to render HTML content in a web browser."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "render_html-1.0.1-py3-none-any.whl", hash = "sha256:c7fc7275931964414a94edc158955c61643fe981eca7e2c65f9311331be77986"},
-    {file = "render_html-1.0.1.tar.gz", hash = "sha256:ae7119b53566f84dc172480a1d8a3cc1fd8d5d3661f2a8537efb24114e97f17f"},
+    {file = "render_html_v2-1.0.0-py3-none-any.whl", hash = "sha256:e060703d590dbad94f6bfa3850bcde0ad8b7ec355a127f0da2deec03f18afd5c"},
+    {file = "render_html_v2-1.0.0.tar.gz", hash = "sha256:f6feb67c79f6b30208ebee4b14c031eae1ceb0327bfcc45f45c1cd2c4b3e5489"},
 ]
 
 [[package]]
@@ -675,4 +675,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8181727bb2abb65bf4218231547bf9bdc5a82a6089d6774d4e10ac3e7c0de4ad"
+content-hash = "f305d6e4ccd673c7ea14501cdc97a1af88db886b5fb209c9550f88dec9d11331"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python = "^3.10"
 numpy = "^2.1.3"
 pandas = "^2.2.3"
 matplotlib = "^3.9.2"
-render-html = "^1.0.1"
+render-html-v2 = "^1.0.0"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/DaymudeLab/CSE355-MachineDesign/issues"

--- a/src/cse355_machine_design/automata/base.py
+++ b/src/cse355_machine_design/automata/base.py
@@ -91,5 +91,5 @@ class _Automata(ABC):
             + '\');document.getElementById("graph").appendChild(n)})</script><div id=graph></div>'
         )
         render_html.render_in_browser(
-            html_contents, str(pathlib.Path.cwd() / "preview.html")
+            html_contents, str(pathlib.Path.cwd() / "preview.html"), encoding='utf-8'
         )

--- a/test.py
+++ b/test.py
@@ -2,20 +2,13 @@ from src.cse355_machine_design import PDA, registry
 
 
 
-def problem5():
-    """
-    L_5 = {w#x | w, x in {0, 1}* and w^R is a substring of x}
-    """
+def testPda():
 
-    Q = {'q0', 'q1', 'q2'}
+    Q = {'q0', 'q1'}
     Sigma = {'0', '1', '#'}
     Gamma = {'0', '1', '$'}
     delta = {
-        ('q0', '_', '_'): {('q1', '$')},
-        ('q1', '0', '_'): {('q1', '0')},
-        ('q1', '1', '_'): {('q1', '1')},
-        ('q1', '#', '_'): {('q2', '_')},
-            
+        ('q0', '0', '0'): {('q1', '0')},
     }
     q0 = "q0"
     F = {}
@@ -26,7 +19,7 @@ def problem5():
 
 if __name__ == "__main__":
     #problem1().submit_as_answer(1)
-    problem5().display_state_diagram()
+    testPda().display_state_diagram()
 
     #problem2().submit_as_answer(2)
     #problem3().submit_as_answer(3)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,38 @@
+from src.cse355_machine_design import PDA, registry
+
+
+
+def problem5():
+    """
+    L_5 = {w#x | w, x in {0, 1}* and w^R is a substring of x}
+    """
+
+    Q = {'q0', 'q1', 'q2'}
+    Sigma = {'0', '1', '#'}
+    Gamma = {'0', '1', '$'}
+    delta = {
+        ('q0', '_', '_'): {('q1', '$')},
+        ('q1', '0', '_'): {('q1', '0')},
+        ('q1', '1', '_'): {('q1', '1')},
+        ('q1', '#', '_'): {('q2', '_')},
+            
+    }
+    q0 = "q0"
+    F = {}
+
+    return PDA(Q, Sigma, Gamma, delta, q0, F)
+
+
+
+if __name__ == "__main__":
+    #problem1().submit_as_answer(1)
+    problem5().display_state_diagram()
+
+    #problem2().submit_as_answer(2)
+    #problem3().submit_as_answer(3)
+    #problem4().submit_as_answer(4)
+    #problem5().submit_as_answer(5)
+    #problem6().submit_as_answer(6)
+    #problem7().submit_as_answer(7)
+
+    registry.export_submissions()


### PR DESCRIPTION
# Problem
Currently when a windows machine wants to display a state diagram that has the → character there is an error
![Screenshot 2024-11-21 005631](https://github.com/user-attachments/assets/368e2e5b-4223-4440-bdae-29fcb4978606)

The reason for this issue lies in the library render-html. render-html does relies on writing and opening a file when rendering it. render-html does not have an interface to select the encoding so the default one for each operating system is chosen. It just so happens to be that windows default is not utf-8 and the windows default encoding does not support the → by default, causing this error. linux and mac os have utf-8 encoding by default so this error does not arise for those operating system.

# Proposed solution
To fix this I have forked render-html and published a package that has kept the interface the same except added an optional parameter for encoding. I have updated the project to use this new package and edited the source code to pass utf-8 encoding when rendering the html. This has fixed the problem.
